### PR TITLE
GEN-194 Add publisher as docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ DB_USER=postgres
 DB_NAME=postgres
 DB_PASSWORD=foobar
 
+pub:
+	@PGPASSWORD=$(DB_PASSWORD) psql -h localhost -p 5435 -U $(DB_USER) -d publisher @ $(DB_NAME)
+
 sub1:
 	@PGPASSWORD=$(DB_PASSWORD) psql -h localhost -p 5433 -U $(DB_USER) -d $(DB_NAME)
 

--- a/pg_hba.conf
+++ b/pg_hba.conf
@@ -1,0 +1,129 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# ----------------------
+# Authentication Records
+# ----------------------
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local         DATABASE  USER  METHOD  [OPTIONS]
+# host          DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl     DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostgssenc    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnogssenc  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type:
+# - "local" is a Unix-domain socket
+# - "host" is a TCP/IP socket (encrypted or not)
+# - "hostssl" is a TCP/IP socket that is SSL-encrypted
+# - "hostnossl" is a TCP/IP socket that is not SSL-encrypted
+# - "hostgssenc" is a TCP/IP socket that is GSSAPI-encrypted
+# - "hostnogssenc" is a TCP/IP socket that is not GSSAPI-encrypted
+#
+# DATABASE can be "all", "sameuser", "samerole", "replication", a
+# database name, a regular expression (if it starts with a slash (/))
+# or a comma-separated list thereof.  The "all" keyword does not match
+# "replication".  Access to replication must be enabled in a separate
+# record (see example below).
+#
+# USER can be "all", a user name, a group name prefixed with "+", a
+# regular expression (if it starts with a slash (/)) or a comma-separated
+# list thereof.  In both the DATABASE and USER fields you can also write
+# a file name prefixed with "@" to include names from a separate file.
+#
+# ADDRESS specifies the set of hosts the record matches.  It can be a
+# host name, or it is made up of an IP address and a CIDR mask that is
+# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
+# specifies the number of significant bits in the mask.  A host name
+# that starts with a dot (.) matches a suffix of the actual host name.
+# Alternatively, you can write an IP address and netmask in separate
+# columns to specify the set of hosts.  Instead of a CIDR-address, you
+# can write "samehost" to match any of the server's own IP addresses,
+# or "samenet" to match any address in any subnet that the server is
+# directly connected to.
+#
+# METHOD can be "trust", "reject", "md5", "password", "scram-sha-256",
+# "gss", "sspi", "ident", "peer", "pam", "ldap", "radius" or "cert".
+# Note that "password" sends passwords in clear text; "md5" or
+# "scram-sha-256" are preferred since they send encrypted passwords.
+#
+# OPTIONS are a set of options for the authentication in the format
+# NAME=VALUE.  The available options depend on the different
+# authentication methods -- refer to the "Client Authentication"
+# section in the documentation for a list of which options are
+# available for which authentication methods.
+#
+# Database and user names containing spaces, commas, quotes and other
+# special characters must be quoted.  Quoting one of the keywords
+# "all", "sameuser", "samerole" or "replication" makes the name lose
+# its special character, and just match a database or username with
+# that name.
+#
+# ---------------
+# Include Records
+# ---------------
+#
+# This file allows the inclusion of external files or directories holding
+# more records, using the following keywords:
+#
+# include           FILE
+# include_if_exists FILE
+# include_dir       DIRECTORY
+#
+# FILE is the file name to include, and DIR is the directory name containing
+# the file(s) to include.  Any file in a directory will be loaded if suffixed
+# with ".conf".  The files of a directory are ordered by name.
+# include_if_exists ignores missing files.  FILE and DIRECTORY can be
+# specified as a relative or an absolute path, and can be double-quoted if
+# they contain spaces.
+#
+# -------------
+# Miscellaneous
+# -------------
+#
+# This file is read on server startup and when the server receives a
+# SIGHUP signal.  If you edit the file on a running system, you have to
+# SIGHUP the server for the changes to take effect, run "pg_ctl reload",
+# or execute "SELECT pg_reload_conf()".
+#
+# ----------------------------------
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records.  In that case you will also need to make PostgreSQL
+# listen on a non-local interface via the listen_addresses
+# configuration parameter, or via the -i or -h command line switches.
+
+# CAUTION: Configuring the system for local "trust" authentication
+# allows any local user to connect as any PostgreSQL user, including
+# the database superuser.  If you do not trust all your local users,
+# use another authentication method.
+
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     trust
+host    replication     all             127.0.0.1/32            trust
+host    replication     all             ::1/128                 trust
+
+host all all all scram-sha-256
+host all all all trust

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,8 @@ TODO:
 3. Have a another segment for full automated two pub/subs.
 4. Describe the makefile and scripts.
 
+## Manual pub/sub
+
 ## Semi-automated setup
 
 We're going to use an image named `subscriber` with containers named `subscriber1` and `subscriber2` for the entire exercise. The following procedure is a fast track, where many of the relevant commands are scripted:

--- a/replication.sh
+++ b/replication.sh
@@ -1,47 +1,87 @@
 #!/bin/bash
 
 # TODO: figure out how to handle created_at and updated_at compatible with Rails.
+# 1. these will have to be done using triggers.
+# 2. do the created_at trigger first, then the updated_at trigger.
+# 3. write some tests to verify the triggers work.
+
+# TODO: load testing the pub/sub system.
+# 1. Set up a publisher database in a container.
+# 2. Write a script to load up the publisher database with a bunch of data. Use Faker.
+# 3. Set up a subscriber database in a container.
+# 4. Constrain the docker images resources.
+# 5. Set up monitoring on the docker images using InfluxDB and Grafana.
+
 # TODO: insert more, then update, then delete. Verify changes propagate to subscriber.
 # TODO: due diligence on https://github.com/shayonj/pg_easy_replicate
 # TODO: due diliegnce on pglogical
 
 # Replication commands for the localhost publisher database.
-dropdb publisher
-createdb publisher
+# dropdb publisher
+# createdb publisher
 
 # Publisher
 # Reminder: -f loads a file, -c indicates a sql command to run.
-psql -f books_schema.sql publisher
-psql -c "CREATE SEQUENCE books_id_seq ;" publisher
-psql -c "ALTER TABLE books ALTER COLUMN id SET DEFAULT nextval('books_id_seq');" publisher
 
-psql -c "\COPY books ("sku", "title", "topic") FROM './books_data.csv' DELIMITER ',' CSV HEADER;" publisher
-psql -c "ALTER SYSTEM SET wal_level = logical;" publisher
-psql -c "CREATE PUBLICATION leadership_pub FOR TABLE books where (topic = 'leadership');" publisher
-psql -c "CREATE PUBLICATION technical_pub FOR TABLE books where (topic = 'technical');" publisher
+PGPASSWORD="foobar"
+PG_HOST="localhost"
+PG_PORT="5435"
+PG_USER="postgres"
+DB_NAME="publisher"
 
-# Now we need to restart
-brew services restart postgresql@16
+# Function to run psql command
+run_psql() {
+  PGPASSWORD=foobar psql -p "$PG_PORT" -h "$PG_HOST" -U "$PG_USER" "$@"
+}
+
+# Prepare the publisher database.
+run_psql -c "DROP DATABASE IF EXISTS $DB_NAME;"
+run_psql -c "CREATE DATABASE $DB_NAME;"
+run_psql -d "$DB_NAME" -f books_schema.sql # -a to echo all
+run_psql -c "CREATE SEQUENCE books_id_seq ;" -d "$DB_NAME"
+run_psql -c "ALTER TABLE books ALTER COLUMN id SET DEFAULT nextval('books_id_seq');" -d "$DB_NAME"
+run_psql -c "\COPY books ("sku", "title", "topic") FROM './books_data.csv' DELIMITER ',' CSV HEADER;" -d "$DB_NAME"
+
+
+# Set up replication on the publisher database.
+run_psql -c "ALTER SYSTEM SET wal_level = logical;" -d "$DB_NAME"
+run_psql -c "ALTER SYSTEM SET listen_addresses = '*'; " -d "$DB_NAME"
+
+docker cp publisher:/var/lib/postgresql/data/pg_hba.conf ./pg_hba.conf
+echo "host all all all trust" >> pg_hba.conf
+docker cp ./pg_hba.conf publisher:/var/lib/postgresql/data/pg_hba.conf
+docker restart publisher
 sleep 1 # wait for the server to restart
 
-# Load up the goodreads export for fun.
-psql -f ./goodreads_pub_schema.sql publisher
-CSV_PATH="./goodreads_export-2023-10-17.csv"
-# HEADER="$(<goodreads_header.txt)" # Save for future reference, very cool
-HEADER=$(head -n 1 goodreads_export-2023-10-17.csv | sed 's/,/","/g; s/^/"/; s/$/"/')
-psql -c "\COPY goodreads_books($HEADER) FROM '$CSV_PATH' DELIMITER ',' CSV HEADER;" publisher
+run_psql -c "CREATE PUBLICATION leadership_pub FOR TABLE books where (topic = 'leadership');"  -d "$DB_NAME"
+run_psql -c "CREATE PUBLICATION technical_pub FOR TABLE books where (topic = 'technical');"  -d "$DB_NAME"
+# Check with SELECT * FROM pg_publication;
+
+# TODO: switch to container. Load up the goodreads export for fun.
+# psql -f ./goodreads_pub_schema.sql publisher
+# CSV_PATH="./goodreads_export-2023-10-17.csv"
+# # HEADER="$(<goodreads_header.txt)" # Save for future reference, very cool
+# HEADER=$(head -n 1 goodreads_export-2023-10-17.csv | sed 's/,/","/g; s/^/"/; s/$/"/')
+# psql -c "\COPY goodreads_books($HEADER) FROM '$CSV_PATH' DELIMITER ',' CSV HEADER;" publisher
+
+# TODO: investigate how this works in more detail.
+# create the network if it doesn't exist, then connect the containers to the network.
+docker network ls | grep -q "pubsub_network" || docker network create pubsub_network
+docker network connect pubsub_network publisher
+docker network connect pubsub_network subscriber1
+docker network connect pubsub_network subscriber2
 
 # Replication commands for the Docker subscriber database.
 # Create subscriber1 database
 # Note: ensure there is no sequence table in the subscriber1 database.
 PGPASSWORD=foobar psql -f books_schema.sql -U postgres -p 5433 -h localhost
-PGPASSWORD=foobar psql -c "CREATE SUBSCRIPTION sub1 CONNECTION 'host=host.docker.internal dbname=publisher' PUBLICATION leadership_pub;" -U postgres -p 5433 -h localhost
+PGPASSWORD=foobar psql -c "CREATE SUBSCRIPTION sub1 CONNECTION 'host=publisher dbname=publisher user=postgres password=foobar' PUBLICATION leadership_pub;" -U postgres -p 5433 -h localhost
 PGPASSWORD=foobar psql -U postgres -p 5433 -h localhost -f ./goodreads_pub_schema.sql
 
 # Create subscriber2 database
 # Note: ensure there is no sequence table in the subscriber2 database.
 PGPASSWORD=foobar psql -f books_schema.sql -U postgres -p 5434 -h localhost
-PGPASSWORD=foobar psql -c "CREATE SUBSCRIPTION sub2 CONNECTION 'host=host.docker.internal dbname=publisher' PUBLICATION technical_pub;" -U postgres -p 5434 -h localhost
+PGPASSWORD=foobar psql -c "CREATE SUBSCRIPTION sub2 CONNECTION 'host=publisher dbname=publisher user=postgres password=foobar' PUBLICATION technical_pub;" -U postgres -p 5434 -h localhost
 PGPASSWORD=foobar psql -U postgres -p 5434 -h localhost -f ./goodreads_pub_schema.sql
 
 echo "All done"

--- a/restart.sh
+++ b/restart.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 
-IMAGE_NAME="subscriber"
+IMAGE_NAME="pubsub"
 DOCKERFILE_PATH="."
 CONFIG_FILE_PATH="."
-CONTAINERS=("subscriber1" "subscriber2")
+CONTAINERS=("subscriber1" "subscriber2" "publisher")
 
 for CONTAINER_NAME in "${CONTAINERS[@]}"; do
   if docker ps -a | grep -qw $CONTAINER_NAME; then
     docker stop $CONTAINER_NAME
-    # docker rm $CONTAINER_NAME # not needed when container is removed with --rm
+    docker rm $CONTAINER_NAME # not needed when container is removed with --rm
   fi
 done
 
 docker buildx build . -t $IMAGE_NAME # -f $DOCKERFILE_PATH .
-docker run --name subscriber1 --rm -p 5433:5432 -e POSTGRES_PASSWORD=foobar -d subscriber
-docker run --name subscriber2 --rm -p 5434:5432 -e POSTGRES_PASSWORD=foobar -d subscriber
+docker run --name subscriber1 -p 5433:5432 -e POSTGRES_PASSWORD=foobar -d pubsub
+docker run --name subscriber2 -p 5434:5432 -e POSTGRES_PASSWORD=foobar -d pubsub
+docker run --name publisher -p 5435:5432 -e POSTGRES_PASSWORD=foobar -d pubsub
 
 # Optional: Remove old Docker images to free up space
 # docker system prune -a


### PR DESCRIPTION
For load testing it's better to run the whole system in docker containers, which can be parametrically configured. Otherwise the risk is locking up localhost.

This change moves the logical replication publisher db to docker.

More:

- Some documentation and TODOs added for future monitoring.
- Bash refactoring for readability