### PR TITLE
GEN-195 add influxdb via docker container

### DIFF
--- a/Dockerfile.influxdb
+++ b/Dockerfile.influxdb
@@ -1,0 +1,15 @@
+# Use the latest InfluxDB image
+FROM influxdb:latest
+
+# Set environment variables for initial admin user and password
+# This does not seem to be working, GPT might be haliucinating.
+# ENV DOCKER_INFLUXDB_INIT_MODE=setup
+# ENV DOCKER_INFLUXDB_INIT_USERNAME=doolin
+# ENV DOCKER_INFLUXDB_INIT_PASSWORD=foobar
+# ENV DOCKER_INFLUXDB_INIT_ORG=inventium
+# ENV DOCKER_INFLUXDB_INIT_BUCKET=testem
+
+# After setting up, update the .zshrc with the token
+# provided after logging in.
+
+# No need to provide an explicit CMD or ENTRYPOINT as the base image provides it

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -5,9 +5,10 @@ source ./helpers.sh
 infotext "This will stop and remove the subscriber docker containers"
 press_enter
 
-containers=("subscriber1" "subscriber2")
+containers=("subscriber1" "subscriber2" "publisher" "pubmetrics")
 for container in "${containers[@]}"; do
   docker stop "$container" >/dev/null 2>&1 # stdout and stderr to /dev/null
+  docker rm "$container" >/dev/null 2>&1
 done
 
 # The nuclear option, deletes all containers and images

--- a/restart.sh
+++ b/restart.sh
@@ -3,7 +3,7 @@
 IMAGE_NAME="pubsub"
 DOCKERFILE_PATH="."
 CONFIG_FILE_PATH="."
-CONTAINERS=("subscriber1" "subscriber2" "publisher")
+CONTAINERS=("subscriber1" "subscriber2" "publisher" "pubmetrics")
 
 for CONTAINER_NAME in "${CONTAINERS[@]}"; do
   if docker ps -a | grep -qw $CONTAINER_NAME; then
@@ -12,10 +12,16 @@ for CONTAINER_NAME in "${CONTAINERS[@]}"; do
   fi
 done
 
+# Locally defined Docker file.
 docker buildx build . -t $IMAGE_NAME # -f $DOCKERFILE_PATH .
-docker run --name subscriber1 -p 5433:5432 -e POSTGRES_PASSWORD=foobar -d pubsub
-docker run --name subscriber2 -p 5434:5432 -e POSTGRES_PASSWORD=foobar -d pubsub
-docker run --name publisher -p 5435:5432 -e POSTGRES_PASSWORD=foobar -d pubsub
+docker run -d --name subscriber1 -p 5433:5432 -e POSTGRES_PASSWORD=foobar $IMAGE_NAME
+docker run -d --name subscriber2 -p 5434:5432 -e POSTGRES_PASSWORD=foobar $IMAGE_NAME
+docker run -d --name publisher -p 5435:5432 -e POSTGRES_PASSWORD=foobar $IMAGE_NAME
+
+# Pull from Docker Hub.
+docker buildx build -t pubmetrics -f Dockerfile.influxdb .
+docker run -d --name pubmetrics -p 8086:8086 -v myInfluxVolume:/var/lib/influxdb2 pubmetrics
+
 
 # Optional: Remove old Docker images to free up space
 # docker system prune -a


### PR DESCRIPTION
One of the goals of this project is examining postgres internal, for which influx will provide a backing store for query results. This commit adds a docker file and script support for push button provisioning.